### PR TITLE
Actualizar nombre de Charla de Andrea - Octubre 2018

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
         <h4>Call for papers</h4>
         <p>
           <a href="https://github.com/lima-js/limajs.org#cómo-proponer-una-charla">
-            Cómo proponer una charla?
+            ¿Cómo proponer una charla?
           </a>
         </p>
       </div>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
           </li>
           <li>
             9:30pm -
-            <strong>¿UX? ¿Qué es qué? Ha llegado el momento de hablar...</strong>
+            <strong>¿UX Designer? ¿Qué es qué? Ha llegado el momento de hablar...</strong>
             por <a href="https://github.com/AndreaCarretero">Andrea Carretero (@AndreaCarretero)</a>
           </li>
           <li>10:00pm - After / BeerJS (en algún lugar cerca)</li>


### PR DESCRIPTION
- Se actualiza el nombre de la charla de Andrea Carretero para Octubre 2018.
- Se hizo un minor fix de un typo