### PR TITLE
Actualiza info sobre cómo proponer charla y otros detalles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,36 +27,19 @@ La manera más fácil de proponer una charla es [abriendo un nuevo _issue_ en es
 repo](https://github.com/lima-js/limajs.org/issues/new). Esto automáticamente
 mostrará una _plantilla_ con instrucciones sobre qué información debes enviar.
 
-Por otro lado, si lo prefieres, también puedes lanzarte a directamentente
-mandarnos un _pull request_ con los cambios a publicar en nuestra página web. Si
-prefieres un PR puedes seguir estos pasos:
-
-1. Haz un `fork` de este repo.
-2. Añade tu nombre y título de charla al anuncio de nuestra próxima reunión en
-   [`index.html`](https://github.com/lima-js/limajs.org/blob/master/index.html).
-3. Crea un pull request con tus cambios. En la descripción del pull request
-   puedes añadir más info y/o referencias.
-4. Espera que se inicie una conversación sobre tu propuesta, y opcionalmente
-   haz cambios a tu propuesta original.
-5. Uno de nuestros commiters aceptará el pull request, hará un "merge" y
-   cerrará el pull request correspondiente.
-
-Si necesitas ayuda con este proceso porque eres nuevo con GitHub o git, no
-dudes en [abrir un issue](https://github.com/lima-js/limajs.org/issues/new) o
-contactarnos por [Twitter](https://twitter.com/LimaJSorg) o
-[Slack](https://holalimajs.herokuapp.com/). Nos encanta ayudar ;-)
+Alternativamente también puedes contactarnos por
+[Twitter](https://twitter.com/LimaJSorg) o [Slack](https://holalimajs.herokuapp.com/).
+Nos encanta ayudar ;-)
 
 ## Organizadores
 
 [![@lizzie136](https://github.com/lizzie136.png?size=100)](https://github.com/lizzie136)
 [![@lupomontero](https://github.com/lupomontero.png?size=100)](https://github.com/lupomontero)
-[![@wixo](https://github.com/wixo.png?size=100)](https://github.com/wixo)
-[![@xpktro](https://github.com/xpktro.png?size=100)](https://github.com/xpktro)
+[![@diananr](https://github.com/diananr.png?size=100)](https://github.com/diananr)
 
 ## Sponsors
 
 [![Laboratoria](https://github.com/Laboratoria.png?size=200)](http://Laboratoria.la/)
-[![Mozilla Perú](https://github.com/mozillaperu.png?size=200)](https://www.mozilla.pe/)
 
 ¿Quieres que tu empresa u organización patrocine estos eventos?
 [Acá puedes ver cómo participar como sponsor](SPONSORS.md).


### PR DESCRIPTION
La intención de este cambio es poner el `README.md` de este repo al día ya que no se había actualizado hace años. El cambio principal es que se han quitado las instrucciones de cómo proponer charla via PR, ya que con la arquitectura actual de la página ya no tiene sentido, ahora la agenda de los meetups viene directamente desde meetup.com.

He aprovechado a actualizar también la lista de organizadores y sponsors para reflejar la situación actual. Esto está siempre abierto a cambios ;-)